### PR TITLE
Improve Readme and obscure values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_DEBUG=true
+APP_DEBUG=false
 APP_KEY=SomeRandomString
 
 DB_HOST=localhost

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Twilio and Laravel.
 1. Install the application's dependencies with [Composer](https://getcomposer.org/)
 
    ```bash
-   $ composer install
+   composer install
    ```
 1. The application uses PostgreSQL as the persistence layer. If you
    don't have it already, you should install it. The easiest way is by
@@ -21,12 +21,12 @@ Twilio and Laravel.
 1. Create a database.
 
    ```bash
-   $ createdb ivr_recording
+   createdb ivr_recording
    ```
 1. Copy the sample configuration file and edit it to match your configuration.
 
     ```bash
-    $ cp .env.example .env
+    cp .env.example .env
     ```
 
    You'll need to set `DB_HOST`, `DB_DATABASE`, `DB_USERNAME`, and
@@ -36,27 +36,27 @@ Twilio and Laravel.
 1. Generate an `APP_KEY`:
 
    ```bash
-   $ php artisan key:generate
+   php artisan key:generate
    ```
 1. Run the migrations:
 
    ```bash
-   $ php artisan migrate
+   php artisan migrate
    ```
 1. Load seed data:
 
    ```bash
-   $ php artisan db:seed
+   php artisan db:seed
    ```
 1. Run the application using Artisan.
 
    ```bash
-   $ php artisan serve
+   php artisan serve
    ```
 1. Expose the application to the wider Internet using [ngrok](https://ngrok.com/)
 
    ```bash
-   $ ngrok http 8000
+   ngrok http 8000
    ```
 1. Provision a number under the
    [Manage Numbers page](https://www.twilio.com/user/account/phone-numbers/incoming)
@@ -74,18 +74,18 @@ This application uses this Twilio helper library:
 1. Configure a test database in `.env.test`.
 1. Run the database migrations for the test database
    ```bash
-   $ APP_ENV=testing php artisan migrate
+   APP_ENV=testing php artisan migrate
    ```
 
 1. Run at the top-level directory:
 
    ```bash
-   $ phpunit --coverage-text
+   phpunit --coverage-text
    ```
 
 If your PHP installation doesn't have `xdebug` support then simply run
 the tests without coverage reporting:
 
 ```bash
-$ phpunit
+phpunit
 ```


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- Add APP_DEBUG to false
- Improve Readme
 

Not possible due to the Laravel version:

- debug_blacklist to avoid exposing sensible variables even when debug is true. It was added in Laravel 5.5.13, and project version is Laravel 5.1